### PR TITLE
Feat: コピペコピー画面のUI改善とタイトル機能の追加

### DIFF
--- a/lib/models/prompt_model.dart
+++ b/lib/models/prompt_model.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class Prompt {
   final String? id;
+  final String title;
   final String text;
   final String? imageUrl;
   final Timestamp timestamp;
@@ -9,6 +10,7 @@ class Prompt {
 
   Prompt({
     this.id,
+    required this.title,
     required this.text,
     this.imageUrl,
     required this.timestamp,
@@ -19,6 +21,7 @@ class Prompt {
     Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
     return Prompt(
       id: doc.id,
+      title: data['title'] ?? '',
       text: data['text'] ?? '',
       imageUrl: data['imageUrl'],
       timestamp: data['timestamp'] ?? Timestamp.now(),
@@ -28,6 +31,7 @@ class Prompt {
 
   Map<String, dynamic> toFirestore() {
     return {
+      'title': title,
       'text': text,
       'imageUrl': imageUrl,
       'timestamp': timestamp,

--- a/lib/screens/prompt_copy_screen.dart
+++ b/lib/screens/prompt_copy_screen.dart
@@ -20,6 +20,7 @@ class PromptCopyScreen extends StatefulWidget {
 
 class _PromptCopyScreenState extends State<PromptCopyScreen> {
   late final FirestoreService _firestoreService;
+  final TextEditingController _titleController = TextEditingController();
   final TextEditingController _textController = TextEditingController();
   final TextEditingController _tagController = TextEditingController();
   List<String> _selectedTags = [];
@@ -74,6 +75,7 @@ class _PromptCopyScreenState extends State<PromptCopyScreen> {
   }
 
   void _showAddPromptDialog({Prompt? prompt}) {
+    _titleController.text = prompt?.title ?? '';
     _textController.text = prompt?.text ?? '';
     _selectedTags = List<String>.from(prompt?.tags ?? []);
     _imageFile = null;
@@ -124,9 +126,13 @@ class _PromptCopyScreenState extends State<PromptCopyScreen> {
                         label: const Text('画像を添付'),
                       ),
                     TextField(
+                      controller: _titleController,
+                      decoration: const InputDecoration(labelText: 'タイトル'),
+                    ),
+                    TextField(
                       controller: _textController,
                       decoration: const InputDecoration(labelText: 'プロンプト'),
-                      maxLines: 5,
+                      maxLines: 10,
                     ),
                     const SizedBox(height: 16),
                     Wrap(
@@ -191,6 +197,7 @@ class _PromptCopyScreenState extends State<PromptCopyScreen> {
 
                 final newPrompt = Prompt(
                   id: prompt?.id,
+                  title: _titleController.text,
                   text: _textController.text,
                   imageUrl: imageUrl,
                   timestamp: prompt?.timestamp ?? Timestamp.now(),
@@ -303,7 +310,20 @@ class _PromptCopyScreenState extends State<PromptCopyScreen> {
                                 ),
                               ),
                             if (prompt.imageUrl != null) const SizedBox(height: 12),
-                            Text(prompt.text, style: const TextStyle(fontSize: 16.0)),
+                            Text(
+                              prompt.title,
+                              style: const TextStyle(
+                                fontSize: 18.0,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              prompt.text,
+                              style: const TextStyle(fontSize: 16.0),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
                             const Divider(),
                             Row(
                               children: [


### PR DESCRIPTION
コピペコピー画面に対して、以下の3点の修正を行いました。

1.  **一覧表示の省略**: 複数行にわたるコピペ内容は、一覧画面で1行に省略し、末尾を「...」で表示するようにしました。
2.  **入力欄の拡大**: 登録・編集画面のコピペ内容入力欄の高さを、従来の2倍に拡大し、より長い文章を編集しやすくしました。
3.  **タイトル機能の追加**:
    *   各コピペ内容にタイトルを設定できるよう、登録・編集画面にタイトル入力欄を追加しました。
    *   設定したタイトルは、一覧画面で各項目の先頭に太字で表示されます。

ビルド環境の問題により、こちらでのAPK生成ができませんでした。お手数ですが、お手元でのご確認をお願いいたします。