### PR TITLE
Fix: キャッシュ取得がペンディングのまま進まない問題を修正

### DIFF
--- a/lib/screens/nas_file_browser_screen.dart
+++ b/lib/screens/nas_file_browser_screen.dart
@@ -460,6 +460,7 @@ class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
         ),
       );
       await _startForegroundService();
+      _cacheDownloaderService.startPollingForForegroundTask();
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(


### PR DESCRIPTION
キャッシュ取得が "pending" のまま進まない問題を修正しました。

**修正内容**
- `nas_file_browser_screen.dart` の `_startCaching` メソッドに、キャッシュジョブ追加後にバックグラウンド処理を開始するトリガーを追加しました。
- これにより、キャッシュ要求が即座に処理されるようになります。