### PR TITLE
Fix: Resolve Android Build Error by Updating Dependencies

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -42,15 +42,15 @@ android {
 }
 
 dependencies {
-    implementation(files("libs/jcifs-ng-2.1.9.jar"))
+    implementation("eu.agno3.jcifs:jcifs-ng:2.1.10")
     implementation("org.slf4j:slf4j-api:1.7.32")
     implementation("org.slf4j:slf4j-simple:1.7.32")
-    implementation("org.bouncycastle:bcprov-jdk15on:1.68")
+
     implementation("org.nanohttpd:nanohttpd:2.3.1")
     implementation("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0")
 }
 
 configurations.all {
-    resolutionStrategy.force("eu.agno3.jcifs:jcifs-ng:2.1.9")
+    resolutionStrategy.force("eu.agno3.jcifs:jcifs-ng:2.1.10")
 }
 


### PR DESCRIPTION
This PR resolves a critical Android build failure caused by a dependency conflict between the Kotlin version and the `jcifs-ng` library.

**Changes:**

- Updated `jcifs-ng` from version `2.1.9` to `2.1.10` in `android/app/build.gradle.kts`.
- Removed a hardcoded dependency on `bouncycastle`, allowing Gradle to resolve the correct version required by the updated `jcifs-ng`.
- Reverted the project's Android source code to its original state before the unsuccessful attempt to migrate to `smbj`.

These changes fix the build issue and should also resolve the original bug related to background downloads, as we can now properly build and test the application.