### PR TITLE
Fix: Handle null file names in NAS file listing to prevent cache failure

### DIFF
--- a/lib/screens/nas_file_browser_screen.dart
+++ b/lib/screens/nas_file_browser_screen.dart
@@ -31,9 +31,9 @@ class SmbNativeFile {
   });
 
   factory SmbNativeFile.fromMap(Map<dynamic, dynamic> map, String currentPath) {
-    final name = (map['name'] as String);
+    // nullチェックを追加し、nullの場合は空文字列をデフォルト値とする
+    final name = map['name'] as String? ?? '';
     
-    // パスの手動正規化と結合
     String normalizedCurrentPath = currentPath.endsWith('/') ? currentPath : '$currentPath/';
     if (currentPath.isEmpty) {
       normalizedCurrentPath = '';
@@ -42,7 +42,8 @@ class SmbNativeFile {
 
     return SmbNativeFile(
       name: name,
-      isDirectory: map['isDirectory'] as bool,
+      // isDirectoryにもnullチェックを追加
+      isDirectory: map['isDirectory'] as bool? ?? false,
       size: map['size'] as int? ?? 0,
       lastModified: map['lastModified'] as int? ?? 0,
       fullPath: fullPath,
@@ -109,7 +110,10 @@ class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
       });
 
       setState(() {
-        _files = files.map((file) => SmbNativeFile.fromMap(file, _currentPath)).toList();
+        _files = files
+            .map((file) => SmbNativeFile.fromMap(file, _currentPath))
+            .where((file) => file.name.isNotEmpty) // nameが空でないものだけをリストに追加
+            .toList();
         _isLoading = false;
       });
     } on PlatformException catch (e) {


### PR DESCRIPTION
This pull request addresses a crash in the NAS viewer's caching feature that occurred when encountering file entries with `null` names.

### Problem
When listing files on an SMB share, some entries were returned from the native layer with a `null` value for the file name. This caused a `type 'Null' is not a subtype of type 'String'` exception in `SmbNativeFile.fromMap` when casting the name, leading to the cache process terminating prematurely and resulting in a 0-byte cache file.

### Solution
1.  **Null-Safe Name Handling:** The `SmbNativeFile.fromMap` factory constructor now checks if the `name` field is `null`. If it is, it defaults to an empty string (`''`) instead of throwing an exception.
2.  **Filter Invalid Entries:** The `_listFiles` method in `NasFileBrowserScreen` has been updated to filter out any `SmbNativeFile` objects with an empty `name`. This prevents invalid entries from being processed or displayed.

These changes make the file listing process more robust and prevent crashes, ensuring that the caching feature works correctly even with problematic directory entries.