### PR TITLE
feat: Store NAS server data in Firestore

### DIFF
--- a/lib/services/nas_server_service.dart
+++ b/lib/services/nas_server_service.dart
@@ -1,28 +1,75 @@
-import 'dart:convert';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import '../models/nas_server_model.dart';
 
 class NasServerService {
-  static const _serversKey = 'nas_servers';
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
 
-  Future<void> saveServers(List<NasServer> servers) async {
-    final prefs = await SharedPreferences.getInstance();
-    final serversJson = servers.map((s) => jsonEncode(s.toJson())).toList();
-    await prefs.setStringList(_serversKey, serversJson);
+  Future<List<NasServer>> getServers() async {
+    final user = _auth.currentUser;
+    if (user == null) return [];
+
+    final snapshot = await _firestore
+        .collection('users')
+        .doc(user.uid)
+        .collection('nas_servers')
+        .get();
+
+    return snapshot.docs.map((doc) => NasServer.fromJson(doc.data())).toList();
   }
 
-  Future<List<NasServer>> loadServers() async {
-    final prefs = await SharedPreferences.getInstance();
-    final serversJson = prefs.getStringList(_serversKey) ?? [];
-    return serversJson.map((s) => NasServer.fromJson(jsonDecode(s))).toList();
+  Future<void> addServer(NasServer server) async {
+    final user = _auth.currentUser;
+    if (user == null) return;
+
+    await _firestore
+        .collection('users')
+        .doc(user.uid)
+        .collection('nas_servers')
+        .doc(server.id)
+        .set(server.toJson());
+  }
+
+  Future<void> updateServer(NasServer server) async {
+    final user = _auth.currentUser;
+    if (user == null) return;
+
+    await _firestore
+        .collection('users')
+        .doc(user.uid)
+        .collection('nas_servers')
+        .doc(server.id)
+        .update(server.toJson());
+  }
+
+  Future<void> deleteServer(String id) async {
+    final user = _auth.currentUser;
+    if (user == null) return;
+
+    await _firestore
+        .collection('users')
+        .doc(user.uid)
+        .collection('nas_servers')
+        .doc(id)
+        .delete();
   }
 
   Future<NasServer?> getServerById(String id) async {
-    final servers = await loadServers();
-    try {
-      return servers.firstWhere((s) => s.id == id);
-    } catch (e) {
-      return null; // 見つからなかった場合
+    final user = _auth.currentUser;
+    if (user == null) return null;
+
+    final doc = await _firestore
+        .collection('users')
+        .doc(user.uid)
+        .collection('nas_servers')
+        .doc(id)
+        .get();
+
+    if (doc.exists) {
+      return NasServer.fromJson(doc.data()!);
+    } else {
+      return null;
     }
   }
 }

--- a/lib/services/nas_service.dart
+++ b/lib/services/nas_service.dart
@@ -1,40 +1,26 @@
-import 'dart:convert';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../models/nas_server_model.dart';
+import 'nas_server_service.dart';
 
 class NasService {
-  static const _serversKey = 'nas_servers';
+  final NasServerService _serverService = NasServerService();
 
-  Future<List<NasServer>> getServers() async {
-    final prefs = await SharedPreferences.getInstance();
-    final serversJson = prefs.getStringList(_serversKey) ?? [];
-    return serversJson.map((json) => NasServer.fromJson(jsonDecode(json))).toList();
+  Future<List<NasServer>> getServers() {
+    return _serverService.getServers();
   }
 
-  Future<void> saveServers(List<NasServer> servers) async {
-    final prefs = await SharedPreferences.getInstance();
-    final serversJson = servers.map((server) => jsonEncode(server.toJson())).toList();
-    await prefs.setStringList(_serversKey, serversJson);
+  Future<void> addServer(NasServer server) {
+    return _serverService.addServer(server);
   }
 
-  Future<void> addServer(NasServer server) async {
-    final servers = await getServers();
-    servers.add(server);
-    await saveServers(servers);
+  Future<void> updateServer(NasServer server) {
+    return _serverService.updateServer(server);
   }
 
-  Future<void> updateServer(NasServer server) async {
-    final servers = await getServers();
-    final index = servers.indexWhere((s) => s.id == server.id);
-    if (index != -1) {
-      servers[index] = server;
-      await saveServers(servers);
-    }
+  Future<void> deleteServer(String id) {
+    return _serverService.deleteServer(id);
   }
 
-  Future<void> deleteServer(String id) async {
-    final servers = await getServers();
-    servers.removeWhere((s) => s.id == id);
-    await saveServers(servers);
+  Future<NasServer?> getServerById(String id) {
+    return _serverService.getServerById(id);
   }
 }


### PR DESCRIPTION
This pull request migrates NAS server data storage from SharedPreferences to Firestore, enabling data persistence across app reinstalls.

Changes include:
- Modified `NasServerService` to use Firestore for CRUD operations.
- Updated `NasService` to act as a proxy for `NasServerService`.
- Added `getServerById` to `NasServerService` and `NasService` to fix a build error in `CacheDownloaderService`.
- No UI changes were necessary as the UI layer correctly uses the `NasService` abstraction.