### PR TITLE
feat: サムネイルのキャッシュ機能を追加

### DIFF
--- a/lib/screens/nas_file_browser_screen.dart
+++ b/lib/screens/nas_file_browser_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:path/path.dart' as p;
 import 'dart:typed_data';
@@ -617,11 +618,16 @@ class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
           );
         } else if (_isImageFile(file.name)) {
           final imageBytes = await File(localPath).readAsBytes();
-          final image = img.decodeImage(imageBytes);
+          final image = await _decodeImage(imageBytes);
           if (image != null) {
             final resizedImage = img.copyResize(image, width: 128);
             thumbnail = Uint8List.fromList(img.encodeJpg(resizedImage, quality: 25));
           }
+
+Future<img.Image?> _decodeImage(Uint8List bytes) async {
+  return await compute(img.decodeImage, bytes);
+}
+
         }
 
         if (thumbnail != null) {

--- a/lib/screens/nas_file_browser_screen.dart
+++ b/lib/screens/nas_file_browser_screen.dart
@@ -23,6 +23,7 @@ import 'package:path/path.dart' as p;
 import 'package:fujitake_app_new/services/cache_path_service.dart';
 import 'package:image/image.dart' as img;
 
+import 'package:fujitake_app_new/utils/image_utils.dart';
 
 
 // ネイティブから受け取るファイル情報を表すクラス
@@ -577,6 +578,7 @@ class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
     return ext == '.jpg' || ext == '.jpeg' || ext == '.png' || ext == '.gif' || ext == '.bmp' || ext == '.webp';
   }
 
+
   Future<void> _getThumbnailData(SmbNativeFile file) async {
     final cacheKey = p.join(widget.server.shareName!, _currentPath, file.name);
     if (_thumbnailCache.containsKey(cacheKey)) {
@@ -618,7 +620,7 @@ class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
           );
         } else if (_isImageFile(file.name)) {
           final imageBytes = await File(localPath).readAsBytes();
-          final image = await _decodeImage(imageBytes);
+          final image = await decodeImageInBackground(imageBytes);
           if (image != null) {
             final resizedImage = img.copyResize(image, width: 128);
             thumbnail = Uint8List.fromList(img.encodeJpg(resizedImage, quality: 25));

--- a/lib/screens/nas_file_browser_screen.dart
+++ b/lib/screens/nas_file_browser_screen.dart
@@ -591,8 +591,9 @@ class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
     }
 
     // フォルダキャッシュ（ファイル本体）の存在を確認
-    final localPath = await _cacheDownloaderService.getLocalPath(
-      'smb://${widget.server.ipAddress}/${widget.server.shareName}/${file.fullPath}',
+    final localPath = await _cachePathService.getLocalPath(
+      widget.server.id,
+      file.fullPath,
     );
 
     if (localPath != null && await File(localPath).exists()) {

--- a/lib/screens/nas_file_browser_screen.dart
+++ b/lib/screens/nas_file_browser_screen.dart
@@ -86,6 +86,7 @@ class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
   static const _smbChannel = MethodChannel('com.example.fujitake_app_new/smb');
   static const String _sortOptionKey = 'nas_sort_option';
   final CacheDownloaderService _cacheDownloaderService = CacheDownloaderService.instance;
+  final CachePathService _cachePathService = CachePathService.instance;
   
   SortOptionValue _sortOptionValue = SortOptionValue.dateDesc;
   List<SmbNativeFile> _files = [];

--- a/lib/screens/nas_file_browser_screen.dart
+++ b/lib/screens/nas_file_browser_screen.dart
@@ -12,6 +12,12 @@ import 'video_viewer_screen.dart';
 import '../models/cache_job_model.dart';
 import '../services/cache_downloader_service.dart';
 import '../services/global_log.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:io';
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
+import 'package:path_provider/path_provider.dart';
+
 
 // ネイティブから受け取るファイル情報を表すクラス
 class SmbNativeFile {
@@ -75,6 +81,7 @@ enum SortOptionValue {
 
 class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
   static const _smbChannel = MethodChannel('com.example.fujitake_app_new/smb');
+  static const String _sortOptionKey = 'nas_sort_option';
   final CacheDownloaderService _cacheDownloaderService = CacheDownloaderService.instance;
   
   SortOptionValue _sortOptionValue = SortOptionValue.dateDesc;
@@ -94,7 +101,9 @@ class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
     super.initState();
     _currentShare = widget.server.shareName;
     _smbChannel.setMethodCallHandler(_handleNativeMethodCalls);
-    _listFiles(path: '');
+    _loadSortOption().then((_) {
+      _listFiles(path: '');
+    });
   }
 
   Future<dynamic> _handleNativeMethodCalls(MethodCall call) async {
@@ -109,6 +118,25 @@ class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
       default:
         break;
     }
+  }
+
+  Future<void> _loadSortOption() async {
+    final prefs = await SharedPreferences.getInstance();
+    final sortOptionName = prefs.getString(_sortOptionKey);
+    if (sortOptionName != null) {
+      try {
+        setState(() {
+          _sortOptionValue = SortOptionValue.values.firstWhere((e) => e.name == sortOptionName);
+        });
+      } catch (e) {
+        // 保存された値が無効な場合はデフォルト値を使用
+      }
+    }
+  }
+
+  Future<void> _saveSortOption(SortOptionValue value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_sortOptionKey, value.name);
   }
 
   Future<void> _listFiles({String path = ''}) async {
@@ -315,10 +343,13 @@ class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
                 ),
                 TextButton(
                   onPressed: () {
-                    this.setState(() {
-                      _sortOptionValue = tempSortOptionValue!;
-                    });
-                    _sortFiles();
+                    if (tempSortOptionValue != null) {
+                      _saveSortOption(tempSortOptionValue!);
+                      setState(() {
+                        _sortOptionValue = tempSortOptionValue!;
+                      });
+                      _sortFiles();
+                    }
                     Navigator.of(context).pop();
                   },
                   child: const Text('確認'),
@@ -540,6 +571,22 @@ class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
       return;
     }
 
+    // ディスクキャッシュのパスを生成
+    final cacheDir = await getTemporaryDirectory();
+    final hash = sha1.convert(utf8.encode(cacheKey)).toString();
+    final cacheFile = File('${cacheDir.path}/thumbnail_$hash.jpg');
+
+    // ディスクキャッシュが存在すればそれを読み込む
+    if (await cacheFile.exists()) {
+      final bytes = await cacheFile.readAsBytes();
+      if (mounted) {
+        setState(() {
+          _thumbnailCache[cacheKey] = bytes;
+        });
+      }
+      return;
+    }
+
     try {
       final Uint8List? thumbnail = await _smbChannel.invokeMethod('getThumbnail', {
         'host': widget.server.host,
@@ -555,6 +602,11 @@ class _NasFileBrowserScreenState extends State<NasFileBrowserScreen> {
           'lastModified': file.lastModified,
         },
       });
+
+      if (thumbnail != null) {
+        // 取得したサムネイルをディスクキャッシュに保存
+        await cacheFile.writeAsBytes(thumbnail);
+      }
 
       if (mounted) {
         setState(() {

--- a/lib/screens/nas_file_browser_screen.dart
+++ b/lib/screens/nas_file_browser_screen.dart
@@ -19,6 +19,7 @@ import 'package:crypto/crypto.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:video_thumbnail/video_thumbnail.dart';
 import 'package:path/path.dart' as p;
+import 'package:fujitake_app_new/services/cache_path_service.dart';
 
 
 

--- a/lib/utils/image_utils.dart
+++ b/lib/utils/image_utils.dart
@@ -1,0 +1,8 @@
+import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
+import 'package:image/image.dart' as img;
+
+// 画像デコード処理をバックグラウンドで実行するためのトップレベル関数
+Future<img.Image?> decodeImageInBackground(Uint8List imageBytes) {
+  return compute(img.decodeImage, imageBytes);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -561,7 +561,7 @@ packages:
     source: hosted
     version: "4.1.2"
   image:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image
       sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -740,10 +740,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1209,10 +1209,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,6 +71,7 @@ dependencies:
 
   collection: ^1.18.0
   crypto: ^3.0.6
+  image: ^4.5.4
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,7 +64,7 @@ dependencies:
 
   permission_handler: ^11.3.1
   share_plus: ^11.1.0
-  video_thumbnail: ^0.5.3
+  video_thumbnail: ^0.5.6
   path: ^1.9.1
   sqflite_common_ffi: ^2.3.0
   flutter_foreground_task: ^9.1.0 # Androidフォアグラウンドサービス用


### PR DESCRIPTION
NASビューワーのファイル一覧画面において、動画/画像ファイルのサムネイル表示をキャッシュするようにしました。

フォルダキャッシュ済みのファイルについては、ローカルファイルからサムネイルを生成するように修正しました。

画像ファイルのサムネイルが正しく表示されない問題を修正しました。

画像サムネイル表示時のフリーズ問題を修正しました。

APKはこちらからダウンロードできます。
https://github.com/onpuuki/fujitake_app_new/releases/download/v2.0.3-freeze-fix/app-arm64-v8a-release.apk