### PR TITLE
Fix: Cache download issue

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -28,7 +28,6 @@ android {
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
-
     }
 
     buildTypes {
@@ -37,9 +36,6 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             signingConfig = signingConfigs.getByName("debug")
             isShrinkResources = true
-            ndk {
-                abiFilters.addAll(listOf("arm64-v8a"))
-            }
         }
     }
 

--- a/android/app/src/main/kotlin/com/example/fujitake_app_new/DownloadWorker.kt
+++ b/android/app/src/main/kotlin/com/example/fujitake_app_new/DownloadWorker.kt
@@ -59,6 +59,7 @@ class DownloadWorker(appContext: Context, workerParams: WorkerParameters) : Coro
                     val relativePath = file.path.substringAfter("smb://$host/$shareName/")
                     val hashedFileName = sha256(relativePath) + ".png"
                     val localFile = File(localPathRoot, hashedFileName)
+                    localFile.parentFile?.mkdirs()
 
                     sendDebugLog("Downloading ${file.path} to ${localFile.path}")
                     FileOutputStream(localFile).use { outputStream ->


### PR DESCRIPTION
This PR fixes a bug where the cache download would fail because the parent directory for the cache files was not being created.

Changes:
- Modified `DownloadWorker.kt` to create the parent directory before writing the cache file.
- Modified `android/app/build.gradle.kts` to remove the `ndk` block from the `defaultConfig` to avoid conflicts with the `--split-per-abi` flag.