### PR TITLE
Feat: Refactor Video Playback to Use a Single Native Player

### DIFF
--- a/android/app/src/main/kotlin/com/example/fujitake_app_new/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/fujitake_app_new/MainActivity.kt
@@ -125,6 +125,13 @@ class MainActivity : FlutterActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+
+        // Register the PlatformViewFactory
+        flutterEngine
+            .platformViewsController
+            .registry
+            .registerViewFactory("video_player_view", VideoPlatformViewFactory())
+
         methodChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
         Companion.methodChannel = methodChannel
 
@@ -145,7 +152,8 @@ class MainActivity : FlutterActivity() {
                 "controlVideoPlayback" -> {
                     val control = call.argument<String>("control")
                     val position = call.argument<Int>("position")
-                    controlVideoPlayback(control, position)
+                    val seconds = call.argument<Int>("seconds")
+                    controlVideoPlayback(control, position, seconds)
                     result.success(null)
                 }
                 "startVideoPlaybackService" -> {
@@ -179,12 +187,13 @@ class MainActivity : FlutterActivity() {
         sendDebugLog("MainActivity: startForegroundService/startService was called.")
     }
 
-    private fun controlVideoPlayback(control: String?, position: Int?) {
-        sendDebugLog("MainActivity: controlVideoPlayback called with control: $control, position: $position")
+    private fun controlVideoPlayback(control: String?, position: Int?, seconds: Int?) {
+        sendDebugLog("MainActivity: controlVideoPlayback called with control: $control, position: $position, seconds: $seconds")
         val intent = Intent(this, VideoPlaybackService::class.java).apply {
             action = "CONTROL_ACTION"
             putExtra("control", control)
-            putExtra("position", position ?: 0)
+            position?.let { putExtra("position", it) }
+            seconds?.let { putExtra("seconds", it) }
         }
         startService(intent)
     }

--- a/android/app/src/main/kotlin/com/example/fujitake_app_new/VideoPlatformView.kt
+++ b/android/app/src/main/kotlin/com/example/fujitake_app_new/VideoPlatformView.kt
@@ -1,0 +1,29 @@
+package com.example.fujitake_app_new
+
+import android.content.Context
+import android.view.View
+import com.google.android.exoplayer2.ui.PlayerView
+import io.flutter.plugin.common.StandardMessageCodec
+import io.flutter.plugin.platform.PlatformView
+import io.flutter.plugin.platform.PlatformViewFactory
+
+class VideoPlatformViewFactory : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
+    override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
+        val creationParams = args as Map<String?, Any?>?
+        return VideoPlatformView(context, viewId, creationParams)
+    }
+}
+
+class VideoPlatformView(context: Context, id: Int, creationParams: Map<String?, Any?>?) : PlatformView {
+    private val playerView: PlayerView = PlayerView(context)
+
+    init {
+        playerView.player = VideoPlaybackService.getPlayerInstance(context)
+    }
+
+    override fun getView(): View {
+        return playerView
+    }
+
+    override fun dispose() {}
+}


### PR DESCRIPTION
This PR resolves the video/audio desync issue by refactoring the video playback mechanism to use a single, continuous ExoPlayer instance managed natively via a PlatformView.

**Changes:**

- Replaced the `video_player` package with a native `PlatformView` implementation using `ExoPlayer`.
- Created `VideoPlatformView.kt` to manage the native `PlayerView`.
- Refactored `VideoPlaybackService.kt` to handle a singleton `ExoPlayer` instance.
- Modified `MainActivity.kt` to register the `VideoPlatformViewFactory`.
- Rewrote `video_viewer_screen.dart` to use an `AndroidView` widget and communicate with the native player via a `MethodChannel`.
- Ensured existing features like Picture-in-Picture (PiP) and 10-second skip functionality remain intact.
- Set up the build environment to successfully build a 64-bit release APK.

**Release:**

The final APK has been uploaded to a GitHub release: [v1.0.0+1](https://github.com/onpuuki/fujitake_app_new/releases/tag/v1.0.0%2B1)